### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/packages/eslint-config-angular/package.json
+++ b/packages/eslint-config-angular/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config-angular"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config",
     "angular"

--- a/packages/eslint-config-astro/package.json
+++ b/packages/eslint-config-astro/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config-astro"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config",
     "astro"

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config-react"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config",
     "react"

--- a/packages/eslint-config-solid/package.json
+++ b/packages/eslint-config-solid/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config-solid"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config",
     "solid-js"

--- a/packages/eslint-config-svelte/package.json
+++ b/packages/eslint-config-svelte/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config-svelte"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config",
     "svelte"

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config-vue"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config",
     "vue"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "eslint-config"
   ],

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/prettier-config"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "prettier-config"
   ],

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -10,6 +10,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/stylelint-config"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "stylelint-config"
   ],

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -9,6 +9,9 @@
     "url": "git@github.com:pengzhanbo/configs.git",
     "directory": "packages/tsconfig"
   },
+  "bugs": {
+    "url": "https://github.com/pengzhanbo/configs/issues"
+  },
   "keywords": [
     "tsconfig"
   ],


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata to the published package manifests
- point npm users to the repository issue tracker for support and bug reports

## Verification

- `node -e "const p=require('./packages/stylelint-config/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage,license:p.license}, null, 2)); if (p.bugs?.url !== 'https://github.com/pengzhanbo/configs/issues') process.exit(1)"`
- `git diff --check`
- `for pkg in ./packages/*; do npm pack "$pkg" --dry-run --json >/tmp/pengzhanbo-pack.json; done`

This is an AI-assisted metadata cleanup.
